### PR TITLE
Support message outputs from tools

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -36,6 +36,7 @@ from .items import (
     RunItem,
     ToolCallItem,
     ToolCallOutputItem,
+    ToolMessageItem,
     TResponseInputItem,
 )
 from .lifecycle import AgentHooks, RunHooks
@@ -71,6 +72,7 @@ from .tool import (
     WebSearchTool,
     default_tool_error_function,
     function_tool,
+    message_tool,
 )
 from .tracing import (
     AgentSpanData,
@@ -197,6 +199,7 @@ __all__ = [
     "HandoffOutputItem",
     "ToolCallItem",
     "ToolCallOutputItem",
+    "ToolMessageItem",
     "ReasoningItem",
     "ModelResponse",
     "ItemHelpers",
@@ -227,6 +230,7 @@ __all__ = [
     "MCPToolApprovalRequest",
     "MCPToolApprovalFunctionResult",
     "function_tool",
+    "message_tool",
     "Usage",
     "add_trace_processor",
     "agent_span",

--- a/src/agents/items.py
+++ b/src/agents/items.py
@@ -159,6 +159,16 @@ class ToolCallOutputItem(
 
 
 @dataclass
+class ToolMessageItem(RunItemBase[Message]):
+    """Represents a message returned directly from a tool."""
+
+    raw_item: Message
+    """The raw message."""
+
+    type: Literal["tool_message_item"] = "tool_message_item"
+
+
+@dataclass
 class ReasoningItem(RunItemBase[ResponseReasoningItem]):
     """Represents a reasoning item."""
 
@@ -204,6 +214,7 @@ RunItem: TypeAlias = Union[
     HandoffOutputItem,
     ToolCallItem,
     ToolCallOutputItem,
+    ToolMessageItem,
     ReasoningItem,
     MCPListToolsItem,
     MCPApprovalRequestItem,

--- a/tests/test_message_tool.py
+++ b/tests/test_message_tool.py
@@ -1,0 +1,33 @@
+import pytest
+from openai.types.responses.response_input_item_param import Message
+
+from agents import Agent, Runner, message_tool
+from agents.items import ToolMessageItem
+
+from .fake_model import FakeModel
+from .test_responses import get_function_tool_call, get_text_message
+
+
+@message_tool
+def simple_msg() -> list[Message]:
+    return [{"type": "message", "role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_message_tool_outputs_messages() -> None:
+    model = FakeModel()
+    agent = Agent(name="test", model=model, tools=[simple_msg])
+    model.add_multiple_turn_outputs([
+        [get_function_tool_call("simple_msg")],
+        [get_text_message("done")],
+    ])
+
+    result = await Runner.run(agent, input="hi")
+
+    assert result.final_output == "done"
+    # Should include original input, tool call, tool message, and final message
+    assert len(result.to_input_list()) == 4
+    tool_msg = result.to_input_list()[2]
+    assert isinstance(result.new_items[1], ToolMessageItem)
+    assert tool_msg["role"] == "user"
+    assert tool_msg["content"] == "hello"

--- a/tests/test_tool_use_behavior.py
+++ b/tests/test_tool_use_behavior.py
@@ -36,7 +36,7 @@ def _make_function_tool_result(
     )
     # For this test we don't care about the specific RunItem subclass, only the output field
     run_item = ToolCallOutputItem(agent=agent, raw_item=raw_item, output=output)
-    return FunctionToolResult(tool=tool, output=output, run_item=run_item)
+    return FunctionToolResult(tool=tool, output=output, run_items=[run_item])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary
- allow tools to mark that they return messages
- provide `message_tool` decorator
- track multiple run items per tool and handle ToolMessageItem
- export new functionality and add tests

### Test plan
- `make format` *(fails: no route to host)*
- `make lint` *(fails: no route to host)*
- `make mypy` *(fails: no route to host)*
- `make tests` *(fails: no route to host)*